### PR TITLE
Refactor: explicit the fact the account name should be lowercase

### DIFF
--- a/queensgambot/src/main/java/net/marvk/chess/queensgambot/QueensGamBotApp.java
+++ b/queensgambot/src/main/java/net/marvk/chess/queensgambot/QueensGamBotApp.java
@@ -33,8 +33,9 @@ public final class QueensGamBotApp {
     public static void main(final String[] args) throws IOException, ParseException {
         final String lichessApiToken = getApiToken(args);
 
+        final String lowercaseAccountName = "QueensGamBot".toLowerCase();
         try (final LichessClient client =
-                     LichessClientBuilder.create("queensgambot", KairukuEngine::new)
+                     LichessClientBuilder.create(lowercaseAccountName, KairukuEngine::new)
                                          .allowAllPerfs(Perf.BULLET, Perf.BLITZ)
                                          .allowAllPerfsOnCasual(true)
                                          .apiToken(lichessApiToken)


### PR DESCRIPTION
Great engine, thank you !

I would suggest making it explicit to provide a lowerCase account name when passing in the `accountName` into the `LichessClientBuilder` class.

Otherwise, the case sensitive `equals()` checks to determine who's turn it is (AI or player) always fails or returns `null`.

It was difficult for me to realize this.