### PR TITLE
Added missing EventResponse.Type entries

### DIFF
--- a/lichess4j/src/main/java/net/marvk/chess/lichess4j/model/EventResponse.java
+++ b/lichess4j/src/main/java/net/marvk/chess/lichess4j/model/EventResponse.java
@@ -3,17 +3,35 @@ package net.marvk.chess.lichess4j.model;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * <a href="https://lichess.org/api#tag/Board/operation/apiStreamEvent">Lichess Event Stream Documentation</a>
+ */
 @Data
 public class EventResponse {
     private final Type type;
     private final Challenge challenge;
-    @SerializedName("game")
-    private final GameStart gameStart;
+    private final Game game;
 
+    /**
+     * <a href="https://lichess.org/api#tag/Board/operation/apiStreamEvent">Lichess Event Stream Documentation</a>
+     */
     public enum Type {
-        @SerializedName("challenge")
-        CHALLENGE,
-        @SerializedName("gameStart")
-        GAME_START;
+        @SerializedName("challenge") CHALLENGE,
+        @SerializedName("challengeCanceled") CHALLENGE_CANCELED,
+        @SerializedName("challengeDeclined") CHALLENGE_DECLINED,
+        @SerializedName("gameFinish") GAME_FINISH,
+        @SerializedName("gameStart") GAME_START;
+
+        /**
+         * Returns all values of the enum as a list.<br>
+         * Alternative to {@link Type#values()}.
+         */
+        public static List<Type> toList() {
+            return Arrays.stream(Type.values()).collect(Collectors.toList());
+        }
     }
 }


### PR DESCRIPTION
According to Lichess documentation: https://lichess.org/api#tag/Board/operation/apiStreamEvent

**Note**: by default the current state of this project would interpret `CHALLENGE_CANCELED`, `CHALLENGE_DECLINED`, and `GAME_FINISH` as `MalformedEvents`